### PR TITLE
Allow automated plurization.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,13 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.3.2",
         "illuminate/support": "4.*",
-        "illuminate/translation": "4.*"
+        "illuminate/translation": "4.*",
+        "doctrine/inflector": "1.0.*@dev"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Intervention/Helper/String.php
+++ b/src/Intervention/Helper/String.php
@@ -2,6 +2,8 @@
 
 namespace Intervention\Helper;
 
+use Doctrine\Common\Inflector\Inflector;
+
 class String
 {
     /**
@@ -38,9 +40,13 @@ class String
      * @param  string  $plural
      * @return string
      */
-    public static function pluralize($count = 1, $singular, $plural)
+    public static function pluralize($count = 1, $singular, $plural = null)
     {
-        return ($count > 1) ? $plural : $singular;
+        if ($count == 1) {
+            return $singular;
+        }
+
+        return is_null($plural) ? Inflector::pluralize($singular) : $plural;
     }
 
     /**

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -4,6 +4,12 @@ use Intervention\Helper\String;
 
 class StringTest extends PHPUnit_Framework_TestCase
 {
+
+    /**
+     * @var Intervention\Helper\String;
+     */
+    protected $stringHelper;
+
     public function setUp()
     {
         $this->stringHelper = new String;
@@ -19,6 +25,18 @@ class StringTest extends PHPUnit_Framework_TestCase
     {
         $plural = $this->stringHelper->pluralize(2, 'car', 'cars');
         $this->assertEquals($plural, 'cars');
+    }
+
+    public function testAutoPluralizeSingular()
+    {
+        $singular = $this->stringHelper->pluralize(1, 'car');
+        $this->assertEquals($singular, 'car');
+    }
+
+    public function testAutoPluralizePlural()
+    {
+        $singular = $this->stringHelper->pluralize(5, 'car');
+        $this->assertEquals($singular, 'cars');
     }
 
     public function testAlternatorArray()


### PR DESCRIPTION
Uses Doctrine's Inflection library to automatically pluralize words.
- Updates minimum version of php to match Doctrine's Inflection library
- Adds phpunit to the require-dev packages
- Adds unit tests for automated pluralization

There are probably other functions that can be ported over from the Doctrine Inflection library.
